### PR TITLE
setMaxSpeed() completion

### DIFF
--- a/Minitel.cpp
+++ b/Minitel.cpp
@@ -38,6 +38,7 @@ Minitel::Minitel(int rx, int tx) : SoftwareSerial(rx, tx) {
 void Minitel::init() {
   Serial.begin(1200);
   begin(1200);
+  setMaxSpeed(); // Set serial speed to 4800
   useDefaultColors();
   refreshSettings();
 }
@@ -553,12 +554,12 @@ void Minitel::transparentVideo() {
 
 
 void Minitel::setMaxSpeed() {
-  /*
-    serialprint7(27);
-    serialprint7(SPEED_4800);
-  */
+  serialprint7(27);
+  serialprint7(58);
+  serialprint7(107);
+  serialprint7(118); // Set minitel serial speed to 4800
+  begin(4800); // Set arduino serial speed to 4800
 }
-
 //
 //
 // SOUND


### PR DESCRIPTION
English : the setMaxSpeed() method has been implemented for Minitel 1B
(4800 bauds) but not for Minitel 2 (9600 bauds). It will works (for
Minitel 2), but not at full speed (4800 vs 9600).

French : La méthode setMaxSpeed() a bien été implémentée pour le
Minitel 1B (4800 bauds), mais pas pour le Minitel 2. Cela marchera
quand même pour le Minitel 2, mais pas à la vitesse maximale (4800 vs
9600).